### PR TITLE
feat: add image quality parameter for static map generation

### DIFF
--- a/__tests_/staticmaps/circle.test.ts
+++ b/__tests_/staticmaps/circle.test.ts
@@ -1,4 +1,4 @@
-import Circle from "../../src/staticmaps/circle"
+import { Circle } from "../../src/staticmaps/features"
 
 describe("Circle class", () => {
   test("constructor assigns properties and defaults", () => {

--- a/__tests_/staticmaps/marker.test.ts
+++ b/__tests_/staticmaps/marker.test.ts
@@ -1,4 +1,4 @@
-import IconMarker from "../../src/staticmaps/marker"
+import { IconMarker } from "../../src/staticmaps/features"
 
 describe("Icon class", () => {
   test("constructor sets default values correctly", () => {

--- a/__tests_/staticmaps/multipolygon.test.ts
+++ b/__tests_/staticmaps/multipolygon.test.ts
@@ -1,4 +1,4 @@
-import MultiPolygon from "../../src/staticmaps/multipolygon"
+import { MultiPolygon } from "../../src/staticmaps/features"
 
 describe("MultiPolygon class", () => {
   test("constructor sets coords and default color, fill and width", () => {

--- a/__tests_/staticmaps/polyline.test.ts
+++ b/__tests_/staticmaps/polyline.test.ts
@@ -1,4 +1,4 @@
-import Polyline from "../../src/staticmaps/polyline"
+import { Polyline } from  "../../src/staticmaps/features"
 import * as utils from "../../src/staticmaps/utils" // for mocking createGeodesicLine
 import { Coordinate } from "../../src/types/types"
 

--- a/__tests_/staticmaps/text.test.ts
+++ b/__tests_/staticmaps/text.test.ts
@@ -1,4 +1,4 @@
-import Text from "../../src/staticmaps/text"
+import { Text } from "../../src/staticmaps/features"
 import { TextOptions } from "../../src/types/types"
 
 describe("Text class", () => {

--- a/src/controllers/staticmaps.controller.ts
+++ b/src/controllers/staticmaps.controller.ts
@@ -2,10 +2,7 @@ import StaticMaps from "../staticmaps/staticmaps"
 import { basemaps } from "../utils/basemaps"
 import logger from "../utils/logger"
 import { Response } from "express"
-import IconMarker from "../staticmaps/marker"
-import Polyline from "../staticmaps/polyline"
-import Circle from "../staticmaps/circle"
-import Text from "../staticmaps/text"
+import {Polyline,  Circle, Text, IconMarker  } from "../staticmaps/features"
 import polyline from "@mapbox/polyline"
 import {
   getCachedTile,
@@ -372,6 +369,7 @@ export function getMapParams(params: MapParamsInput): MapParamsOutput {
   }
 
   const center = parseCenter(params.center)
+  const quality = parseInt(params.quality || 100)
 
   const hasCoords = Object.values(features).some((list) =>
     Array.isArray(list)
@@ -404,6 +402,7 @@ export function getMapParams(params: MapParamsInput): MapParamsOutput {
     reverseY: params.reverseY,
     format: params.format || "png",
     center,
+    quality: quality,
     ...features,
   }
 
@@ -537,9 +536,7 @@ export async function generateMap(options: any): Promise<Buffer> {
     throw new Error(errMsg)
   }
 
-  const imageBuffer = await map.image.buffer(`image/${options.format}`, {
-    quality: 100,
-  })
+  const imageBuffer = await map.image.buffer(`image/${options.format}`)
 
   return imageBuffer
 }

--- a/src/staticmaps/features.ts
+++ b/src/staticmaps/features.ts
@@ -1,0 +1,8 @@
+// src/staticmaps/shapes.ts
+export { default as IconMarker } from "./features/marker"
+export { default as Polyline } from "./features/polyline"
+export { default as MultiPolygon } from "./features/multipolygon"
+export { default as Circle } from "./features/circle"
+export { default as Text } from "./features/text"
+export { default as Bound } from "./bound"
+export { default as Image } from "./image"

--- a/src/staticmaps/features/circle.ts
+++ b/src/staticmaps/features/circle.ts
@@ -1,4 +1,4 @@
-import { Coordinate } from "src/types/types"
+import { Coordinate } from "../../types/types"
 
 /**
  * Represents a circle with a center coordinate, radius, color, fill, and line width.

--- a/src/staticmaps/features/marker.ts
+++ b/src/staticmaps/features/marker.ts
@@ -1,4 +1,4 @@
-import { IconOptions, Coordinate } from "src/types/types"
+import { IconOptions, Coordinate } from "../../types/types"
 
 /**
  * Class to handle icon operations.

--- a/src/staticmaps/features/multipolygon.ts
+++ b/src/staticmaps/features/multipolygon.ts
@@ -1,4 +1,4 @@
-import { MultiPolygonOptions, Coordinate } from "src/types/types"
+import { MultiPolygonOptions, Coordinate } from "../../types/types"
 
 /**
  * Class to handle MultiPolygon operations.

--- a/src/staticmaps/features/polyline.ts
+++ b/src/staticmaps/features/polyline.ts
@@ -1,5 +1,5 @@
-import { createGeodesicLine } from "./utils"
-import { PolylineOptions, Coordinate } from "../types/types"
+import { createGeodesicLine } from "../utils"
+import { PolylineOptions, Coordinate } from "../../types/types"
 
 /**
  * Class to handle Polyline operations.

--- a/src/staticmaps/features/text.ts
+++ b/src/staticmaps/features/text.ts
@@ -1,4 +1,4 @@
-import { TextOptions, Coordinate } from "src/types/types"
+import { TextOptions, Coordinate } from "../../types/types"
 
 /**
  * Class to handle Text operations.

--- a/src/staticmaps/shapes.ts
+++ b/src/staticmaps/shapes.ts
@@ -1,8 +1,0 @@
-// src/staticmaps/shapes.ts
-export { default as IconMarker } from "./marker"
-export { default as Polyline } from "./polyline"
-export { default as MultiPolygon } from "./multipolygon"
-export { default as Circle } from "./circle"
-export { default as Text } from "./text"
-export { default as Bound } from "./bound"
-export { default as Image } from "./image"

--- a/src/staticmaps/staticmaps.ts
+++ b/src/staticmaps/staticmaps.ts
@@ -222,8 +222,6 @@ class StaticMaps {
       this.centerY = latToY(centerLat, this.zoom)
     }
 
-    
-    console.log(this.options)
     this.image = new Image(this.options)
 
     // Await drawLayer for each tile layer

--- a/src/staticmaps/staticmaps.ts
+++ b/src/staticmaps/staticmaps.ts
@@ -1,5 +1,5 @@
 import sharp from "sharp"
-import { Image, IconMarker, Polyline, MultiPolygon, Circle, Text, Bound } from "./shapes"
+import { Image, IconMarker, Polyline, MultiPolygon, Circle, Text, Bound } from "./features"
 import TileServerConfig from "./tileserverconfig"
 import {
   workOnQueue,
@@ -44,6 +44,7 @@ class StaticMaps {
   centerX: number
   centerY: number
   zoom: number
+  quality: number
   paddingY: number
   paddingX: number
   image: any
@@ -86,6 +87,7 @@ class StaticMaps {
       min: zoomRange.min || 1,
       max: this.options.zoomRange?.max || 17, // maxZoom
     }
+    this.quality = this.options.quality || 100
 
     // Features
     this.markers = []
@@ -198,6 +200,7 @@ class StaticMaps {
       )
     }
 
+    this.options.quality = this.quality
     this.center = center
     this.zoom = zoom || this.calculateZoom()
 
@@ -219,6 +222,8 @@ class StaticMaps {
       this.centerY = latToY(centerLat, this.zoom)
     }
 
+    
+    console.log(this.options)
     this.image = new Image(this.options)
 
     // Await drawLayer for each tile layer

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,8 +1,8 @@
 // src/types.ts
 
 import { Request } from "express"
-import IconMarker from "../staticmaps/marker"
-import Polyline from "../staticmaps/polyline"
+import IconMarker from "../staticmaps/features/marker"
+import Polyline from "../staticmaps/features/polyline"
 
 /**
  * Coordinate as [longitude, latitude].
@@ -53,6 +53,7 @@ export interface MapOptions {
   tileRequestLimit?: number // Max number of tile requests
   reverseY?: boolean // Whether to reverse Y tile Coordinate
   zoomRange?: { min?: number; max?: number } // Allowed zoom range
+  quality?: number
 }
 
 /**


### PR DESCRIPTION
This adds support for a `quality` query parameter that controls the output quality of generated images. Useful for balancing image size and clarity, especially for JPEG output formats.