### PR TITLE
fix: handle array query params when generating cache key

### DIFF
--- a/__tests__/utils/cache.test.ts
+++ b/__tests__/utils/cache.test.ts
@@ -39,7 +39,7 @@ describe("tileCache module", () => {
 
     const key = cache.createCacheKeyFromRequest(req)
     expect(key).toBe(
-      "GET:/staticmaps?center=-119.49280%2C37.81084&zoom=9&layers=topo"
+      "GET:/staticmaps?center=-119.49280%2C37.81084&layers=topo&zoom=9"
     )
   })
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -45,12 +45,16 @@ export function createCacheKeyFromRequest(req: MapRequest): string {
     return devKey
   }
 
-  const queryParams = Object.entries(req.query)
-    .filter(([, v]) => typeof v === "string")
-    .reduce<Record<string, string>>((acc, [k, v]) => {
-      acc[k] = v as string
-      return acc
-    }, {})
+const queryParams = Object.entries(req.query)
+  .map(([k, v]) => {
+    if (Array.isArray(v)) {
+      return [k, v.join(",")]; // join array values with a comma
+    }
+    return [k, v as string];
+  })
+  .sort(([a], [b]) => a.localeCompare(b)) // sort keys for consistent order
+  .map(([k, v]) => `${k}=${v}`) // turn into key=value strings
+  .join("&"); // join to form cache key string
 
   const queryString = new URLSearchParams(queryParams).toString()
   const cacheKey = `${req.method}:${req.path}?${queryString}`


### PR DESCRIPTION
- Normalize query parameters including arrays like `markers`
- Join array values with commas to produce consistent cache key
- Sort keys to ensure deterministic output regardless of param order