### PR TITLE
fixed offsetX and offsetY for markesrs

### DIFF
--- a/src/staticmaps/renderer.ts
+++ b/src/staticmaps/renderer.ts
@@ -457,7 +457,15 @@ export async function loadMarkers(
 
   markers.forEach((marker: any, index: number) => {
     const icon = icons[index]
-    marker.offset = [icon.width / 2, icon.height]
+
+    const offsetX = Number.isFinite(marker.offsetX)
+      ? marker.offsetX
+      : icon.width / 2
+    const offsetY = Number.isFinite(marker.offsetY)
+      ? marker.offsetY
+      : icon.height
+
+    marker.offset = [offsetX, offsetY]
 
     marker.coord = [
       xToPx(lonToX(marker.coord[0], zoom)) - marker.offset[0],


### PR DESCRIPTION
Hello, I've been having a lot of fun building a tool around your code. I noticed that the offset parameter doesnt work. Upon further inspection turns out loadMarkers() overwrites the passed params and resets the offset to half the icon width and height so evert marker is centered regardless of the values. This is my first pull request. Let me know if you have any feedback :) Cheers