### PR TITLE
Protect demo page with API key while preserving demo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,22 @@ A small demo UI is available at [http://localhost:3000](http://localhost:3000 "D
 
 ## 📚 Table of Contents
 
-- [Installation & Configuration](#️-installation--configuration)
-  - [Supported Environment Variables](#️-supported-environment-variables)
-  - [Docker Deployment](#-docker-deployment)
-- [API Reference](#-api-reference)
+- [🛠️ Installation & Configuration](#️-installation--configuration)
+  - [⚙️ Supported Environment Variables](#️-supported-environment-variables)
+  - [🔑 API Key Authentication](#-api-key-authentication)
+  - [🐳 Docker Deployment](#-docker-deployment)
+- [🧑‍💻 API Reference](#-api-reference)
   - [Required Parameters](#required-parameters)
   - [Optional Parameters](#optional-parameters)
-  - [Basemap](#-basemap)
-  - [Attribution](#-attribution)
-  - [Polylines](#️-polylines)
-  - [Polygons](#-polygons)
-  - [Markers](#-markers)
-  - [Circles](#-circles)
-  - [Text](#-text)
-  - [More usage examples](#-more-usage-examples)
-- [Development](#-development)
+  - [🌍 Basemap](#-basemap)
+  - [📝 Attribution](#-attribution)
+  - [🖊️ Polylines](#️-polylines)
+  - [🔲 Polygons](#-polygons)
+  - [📍 Markers](#-markers)
+  - [⚪ Circles](#-circles)
+  - [🔤 Text](#-text)
+  - [🔍 More usage examples](#-more-usage-examples)
+- [💻 Development](#-development)
 
 ## 🛠️ Installation & Configuration
 
@@ -68,6 +69,46 @@ A small demo UI is available at [http://localhost:3000](http://localhost:3000 "D
 | `DISABLE_TILE_CACHE` | `boolean` | `false` | Set to `true` to disable tile caching |
 | `RATE_LIMIT_MS` | `number` | `60000` | Rate limit window in milliseconds |
 | `RATE_LIMIT_MAX` | `number` | `60` | Max requests per IP per window |
+
+### 🔑 API Key Authentication
+
+You can optionally restrict access to the API using an API key.
+
+* **Set an API key** using the environment variable `API_KEY`.
+* **If no key is set**, the API runs in keyless mode (anyone can access it).
+* **Demo endpoints** (`/demo-map`) are accessible either via a valid `demo_auth=true` cookie **or** a valid API key.
+
+
+| Name      | Type   | Default | Description                             |
+| --------- | ------ | ------- | --------------------------------------- |
+| `API_KEY` | string | (none)  | Optional key to restrict access to API. |
+
+#### Passing the API Key
+
+You can provide the API key in two ways:
+
+1. **Header**: `x-api-key`
+
+```bash
+curl -H "x-api-key: your_api_key_here" "http://localhost:3000/api/staticmaps?width=600&height=600&center=40.7128,-74.006&zoom=12"
+```
+
+2. **Query parameter**:
+
+```
+http://localhost:3000/api/staticmaps?width=600&height=600&center=40.7128,-74.006&zoom=12&API_KEY=your_api_key_here
+```
+
+> ✅ Both methods are supported for **all endpoints**, including demo maps.
+
+#### Demo Page Access
+
+* If running without an API key, the demo UI at [http://localhost:3000](http://localhost:3000) works with a browser cookie: `demo_auth=true`.
+* If API key authentication is enabled, you can access the demo page by passing the key in `x-api-key` or `api_key` query parameter.
+
+```bash
+curl "http://localhost:3000/?api_key=your_api_key_here"
+```
 
 ### 🐳 Docker Deployment
 

--- a/__tests__/middlewares/apiKeyAuth.test.ts
+++ b/__tests__/middlewares/apiKeyAuth.test.ts
@@ -20,6 +20,8 @@ describe("authenticateApiKey middleware", () => {
   let req: Partial<Request>
   let res: Partial<Response>
   let next: NextFunction
+  let AuthConfig: typeof import("../../src/middlewares/authConfig").default
+  let authenticateApiKey: typeof import("../../src/middlewares/apiKeyAuth").authenticateApiKey
 
   const OLD_ENV = process.env
 
@@ -31,20 +33,20 @@ describe("authenticateApiKey middleware", () => {
       json: jest.fn(),
     }
     next = jest.fn()
+
+    AuthConfig = require("../../src/middlewares/authConfig").default
+    authenticateApiKey =
+      require("../../src/middlewares/apiKeyAuth").authenticateApiKey
   })
 
   afterAll(() => {
     process.env = OLD_ENV
   })
 
-  test("logs keyless mode info if no API_KEY set", () => {
+  test("keyless mode: next is called if no API_KEY set", () => {
     delete process.env.API_KEY
-
-    const { authenticateApiKey } = require("../../src/middlewares/apiKeyAuth")
-    const AuthConfig = require("../../src/middlewares/authConfig").default
-
-    // call init manually for test to simulate startup
     AuthConfig.init()
+
     expect(mockInfo).toHaveBeenCalledWith(
       "No API key set - running in keyless mode"
     )
@@ -53,52 +55,56 @@ describe("authenticateApiKey middleware", () => {
     expect(next).toHaveBeenCalled()
   })
 
-  test("logs API key enabled info if API_KEY is set", () => {
+  test("API key enabled: next is called if correct header provided", () => {
     process.env.API_KEY = "secret123"
-
-    const { authenticateApiKey } = require("../../src/middlewares/apiKeyAuth")
-    const AuthConfig = require("../../src/middlewares/authConfig").default
-
     AuthConfig.init()
+
     expect(mockInfo).toHaveBeenCalledWith("🔑 API key authentication enabled")
 
     req.headers = { "x-api-key": "secret123" }
     authenticateApiKey(req as Request, res as Response, next)
     expect(next).toHaveBeenCalled()
-  })
-
-  test("calls next immediately when keyless mode enabled", () => {
-    delete process.env.API_KEY
-
-    const { authenticateApiKey } = require("../../src/middlewares/apiKeyAuth")
-    const AuthConfig = require("../../src/middlewares/authConfig").default
-
-    AuthConfig.init()
-    authenticateApiKey(req as Request, res as Response, next)
-    expect(next).toHaveBeenCalled()
-  })
-
-  test("calls next if correct API key provided in header", () => {
-    process.env.API_KEY = "secret123"
-    const { authenticateApiKey } = require("../../src/middlewares/apiKeyAuth")
-    const AuthConfig = require("../../src/middlewares/authConfig").default
-
-    AuthConfig.init()
-    req.headers = { "x-api-key": "secret123" }
-
-    authenticateApiKey(req as Request, res as Response, next)
-    expect(next).toHaveBeenCalled()
     expect(res.status).not.toHaveBeenCalled()
   })
 
-  test("returns 403 and logs warn if wrong API key provided", () => {
+  test("API key correct in query param api_key", () => {
     process.env.API_KEY = "secret123"
-    const { authenticateApiKey } = require("../../src/middlewares/apiKeyAuth")
-    const AuthConfig = require("../../src/middlewares/authConfig").default
-
     AuthConfig.init()
-    req.headers = { "x-api-key": "wrongkey" }
 
+    req.query = { api_key: "secret123" }
+    authenticateApiKey(req as Request, res as Response, next)
+    expect(next).toHaveBeenCalled()
+  })
+
+  test("API key correct in query param API_KEY", () => {
+    process.env.API_KEY = "secret123"
+    AuthConfig.init()
+
+    req.query = { API_KEY: "secret123" }
+    authenticateApiKey(req as Request, res as Response, next)
+    expect(next).toHaveBeenCalled()
+  })
+
+  test("API key missing when required returns 403", () => {
+    process.env.API_KEY = "secret123"
+    AuthConfig.init()
+
+    authenticateApiKey(req as Request, res as Response, next)
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Unauthorized access from IP=127.0.0.1, API key=[REDACTED]"
+    )
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Forbidden: Invalid or missing API key",
+    })
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  test("wrong API key returns 403 and logs warn", () => {
+    process.env.API_KEY = "secret123"
+    AuthConfig.init()
+
+    req.headers = { "x-api-key": "wrongkey" }
     authenticateApiKey(req as Request, res as Response, next)
     expect(mockWarn).toHaveBeenCalledWith(
       "Unauthorized access from IP=127.0.0.1, API key=[REDACTED]"

--- a/__tests__/middlewares/authConfig.test.ts
+++ b/__tests__/middlewares/authConfig.test.ts
@@ -1,0 +1,136 @@
+import { Request, Response, NextFunction } from "express"
+
+// Mock logger
+const mockInfo = jest.fn()
+jest.mock("../../src/utils/logger", () => ({
+  info: mockInfo,
+}))
+
+// Reset modules and clear mocks before each test
+beforeEach(() => {
+  jest.resetModules()
+  jest.clearAllMocks()
+})
+
+describe("AuthConfig", () => {
+  let AuthConfig: typeof import("../../src/middlewares/authConfig").default
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    AuthConfig = require("../../src/middlewares/authConfig").default
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  describe("init()", () => {
+    test("sets requireAuth to false when no API_KEY", () => {
+      delete process.env.API_KEY
+      AuthConfig.init()
+
+      expect(AuthConfig.apiKey).toBeUndefined()
+      expect(AuthConfig.requireAuth).toBe(false)
+      expect(mockInfo).toHaveBeenCalledWith(
+        "No API key set - running in keyless mode"
+      )
+    })
+
+    test("sets requireAuth to true when API_KEY is set", () => {
+      process.env.API_KEY = "secret123"
+      AuthConfig.init()
+
+      expect(AuthConfig.apiKey).toBe("secret123")
+      expect(AuthConfig.requireAuth).toBe(true)
+      expect(mockInfo).toHaveBeenCalledWith("🔑 API key authentication enabled")
+    })
+  })
+
+  describe("extractApiKey()", () => {
+    beforeEach(() => {
+      AuthConfig.init()
+    })
+
+    test("extracts key from x-api-key header", () => {
+      const req = {
+        headers: { "x-api-key": "headerkey" },
+        query: {},
+      } as unknown as Request
+      expect(AuthConfig.extractApiKey(req)).toBe("headerkey")
+    })
+
+    test("extracts key from query param api_key", () => {
+      const req = {
+        headers: {},
+        query: { api_key: "querykey" },
+      } as unknown as Request
+      expect(AuthConfig.extractApiKey(req)).toBe("querykey")
+    })
+
+    test("extracts key from query param API_KEY", () => {
+      const req = {
+        headers: {},
+        query: { API_KEY: "queryKEY" },
+      } as unknown as Request
+      expect(AuthConfig.extractApiKey(req)).toBe("queryKEY")
+    })
+
+    test("returns undefined if no key present", () => {
+      const req = { headers: {}, query: {} } as Request
+      expect(AuthConfig.extractApiKey(req)).toBeUndefined()
+    })
+  })
+
+  describe("checkDemoCookie()", () => {
+    let req: Partial<Request>
+    let res: Partial<Response>
+    let next: NextFunction
+
+    beforeEach(() => {
+      req = { headers: {} }
+      res = {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn(),
+      }
+      next = jest.fn()
+    })
+
+    test("calls next() if demo_auth cookie is true", () => {
+      req.headers!.cookie = "demo_auth=true"
+      AuthConfig.checkDemoCookie(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+
+    test("returns 401 if no cookie header present", () => {
+      AuthConfig.checkDemoCookie(req as Request, res as Response, next)
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.send).toHaveBeenCalledWith("Unauthorized")
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test("returns 401 if demo_auth cookie is not true", () => {
+      req.headers!.cookie = "demo_auth=false"
+      AuthConfig.checkDemoCookie(req as Request, res as Response, next)
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.send).toHaveBeenCalledWith("Unauthorized")
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test("handles multiple cookies and still calls next() when demo_auth=true", () => {
+      req.headers!.cookie = "other=123; demo_auth=true; another=456"
+      AuthConfig.checkDemoCookie(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+
+    test("handles multiple cookies and blocks when demo_auth not present", () => {
+      req.headers!.cookie = "other=123; another=456"
+      AuthConfig.checkDemoCookie(req as Request, res as Response, next)
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.send).toHaveBeenCalledWith("Unauthorized")
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       }
 
       h1 {
-        margin:0;
+        margin: 0;
         font-size: 1.5rem;
       }
 
@@ -82,7 +82,9 @@
 
     <p>
       <strong>Current Static Map URL:</strong>
-      <span id="staticMapUrlDisplay" style="word-break: break-all;">/staticmaps?</span>
+      <span id="staticMapUrlDisplay" style="word-break: break-all"
+        >/staticmaps?</span
+      >
     </p>
 
     <script src="ol.js"></script>
@@ -177,7 +179,7 @@
         const lat = centerLonLat[1]
         const lon = centerLonLat[0]
         const currentZoom = Math.round(view.getZoom())
-        const staticMapUrl = `/staticmaps?width=${mapWidth}&height=${height}&center=${encodeURIComponent(lat + "," + lon)}&zoom=${currentZoom}&basemap=${currentBasemap}`
+        const staticMapUrl = `/demo-map?width=${mapWidth}&height=${height}&center=${encodeURIComponent(lat + "," + lon)}&zoom=${currentZoom}&basemap=${currentBasemap}`
 
         // Update the URL display
         document.getElementById("staticMapUrlDisplay").textContent =

--- a/src/middlewares/apiKeyAuth.ts
+++ b/src/middlewares/apiKeyAuth.ts
@@ -8,24 +8,6 @@ import logger from "../utils/logger"
 import AuthConfig from "./authConfig"
 
 /**
- * Extracts the API key from the request.
- * Checks in order:
- * 1. `x-api-key` header
- * 2. `api_key` query parameter
- * 3. `API_KEY` query parameter
- *
- * @param req Express request object
- * @returns API key if present, otherwise undefined
- */
-function extractApiKey(req: Request): string | undefined {
-  return (
-    req.headers["x-api-key"]?.toString() ||
-    req.query.api_key?.toString() ||
-    req.query.API_KEY?.toString()
-  )
-}
-
-/**
  * Express middleware to enforce API key authentication.
  *
  * - If `API_KEY` is set in environment, clients must supply the correct key.
@@ -44,7 +26,7 @@ export function authenticateApiKey(
 ): void {
   if (!AuthConfig.requireAuth) return next()
 
-  const key = extractApiKey(req)
+  const key = AuthConfig.extractApiKey(req)
   if (key === AuthConfig.apiKey) return next()
 
   logger.warn(`Unauthorized access from IP=${req.ip}, API key=[REDACTED]`)

--- a/src/middlewares/authConfig.ts
+++ b/src/middlewares/authConfig.ts
@@ -45,7 +45,10 @@ class AuthConfig {
    */
   static extractApiKey(req: Request): string | undefined {
     return (
+       // API key from header first (preferred)
       req.headers["x-api-key"]?.toString() ||
+
+      // API key from query string (required for docker-staticmaps use case)
       req.query.api_key?.toString() ||
       req.query.API_KEY?.toString()
     )


### PR DESCRIPTION
- Added API key authentication to root `/` demo page
- Inject API key into demo page JS for demo-map requests
- Updated AuthConfig with checkDemoCookie middleware
- Extended apiKeyAuth and AuthConfig for seamless demo integration
- Ensures demo is only accessible to users with valid API key

fixes #53 