### PR TITLE
chore(docker): add build attestations and harden image defaults

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -81,6 +81,8 @@ jobs:
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/docker-staticmaps:${{ github.sha }}
             ${{ secrets.DOCKER_HUB_USERNAME }}/docker-staticmaps:latest
@@ -97,6 +99,8 @@ jobs:
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/docker-staticmaps:${{ github.event.release.tag_name }}
             ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # -------- Stage 1: Build --------
-FROM node:26-alpine AS build
+FROM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS build
 
 # Metadata
 LABEL org.opencontainers.image.title="docker-staticmaps"
@@ -27,13 +27,13 @@ COPY . .
 RUN npm run build
 
 # Remove dev dependencies to keep only production deps and native modules
-RUN npm prune --production
+RUN npm prune --omit=dev
 
 # Clean npm cache to save space
 RUN npm cache clean --force
 
 # Stage 2: Final Stage (Minimal Image)
-FROM node:26-alpine AS final
+FROM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS final
 
 # Patch base OS packages and install a font for sharp's SVG text rendering
 RUN apk upgrade --no-cache && \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   docker-staticmaps:
     image: mxdcodes/docker-staticmaps:latest
@@ -13,3 +11,12 @@ services:
       - TILE_CACHE_TTL=3600
       - RATE_LIMIT_MS=60000
       - RATE_LIMIT_MAX=60
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 1g
+    pids_limit: 256


### PR DESCRIPTION
- publish SLSA provenance (mode=max) and SPDX SBOM with pushed images
- pin node:26-alpine base image by digest in both build stages
- replace deprecated npm prune --production with --omit=dev
- harden example compose: read-only rootfs, cap_drop ALL, no-new-privileges, tmpfs /tmp, memory and pids limits