### PR TITLE
fix(security)!: resolve DNS before outbound fetches to block SSRF

### DIFF
--- a/__tests__/staticmaps/renderer.markers.test.ts
+++ b/__tests__/staticmaps/renderer.markers.test.ts
@@ -1,7 +1,13 @@
 import sharp from "sharp"
 import { drawMarkers, loadMarkers } from "../../src/staticmaps/renderer"
+import { safeFetch } from "../../src/utils/safeFetch"
 
 jest.mock("sharp")
+
+// Mock the outbound fetch used for remote marker icons
+jest.mock("../../src/utils/safeFetch", () => ({
+  safeFetch: jest.fn(),
+}))
 
 const mockSharpInstance = {
   metadata: jest.fn(),
@@ -184,8 +190,7 @@ describe("loadMarkers", () => {
     sharpMock.mockImplementation(() => sharpInstance as any)
     sharpInstance.toBuffer.mockResolvedValue(Buffer.from("imagebuffer"))
 
-    // Reset fetch mock
-    global.fetch = jest.fn()
+    ;(safeFetch as jest.Mock).mockReset()
   })
 
   it("returns true immediately if markers empty", async () => {
@@ -207,9 +212,11 @@ describe("loadMarkers", () => {
 
     // Mock fetch to return a successful response with image data
     const arrayBuffer = new Uint8Array([1, 2, 3]).buffer
-    ;(global.fetch as jest.Mock).mockResolvedValue({
+    ;(safeFetch as jest.Mock).mockResolvedValue({
       ok: true,
-      headers: { get: (name: string) => name === "content-type" ? "image/png" : null },
+      headers: {
+        get: (name: string) => (name === "content-type" ? "image/png" : null),
+      },
       arrayBuffer: jest.fn().mockResolvedValue(arrayBuffer),
     })
 
@@ -219,9 +226,9 @@ describe("loadMarkers", () => {
 
     const result = await loadMarkers(markers as any, 2, xToPx, yToPx)
 
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(safeFetch).toHaveBeenCalledWith(
       "https://example.com/marker.png",
-      expect.objectContaining({ method: "GET", redirect: "manual" })
+      expect.objectContaining({ maxBytes: expect.any(Number) })
     )
     expect(sharpMock).toHaveBeenCalled()
     expect(sharpInstance.resize).toHaveBeenCalledWith(10, 15)
@@ -280,7 +287,7 @@ describe("loadMarkers", () => {
       },
     ]
 
-    ;(global.fetch as jest.Mock).mockResolvedValue({
+    ;(safeFetch as jest.Mock).mockResolvedValue({
       ok: false,
     })
 

--- a/__tests__/staticmaps/tilemanager.test.ts
+++ b/__tests__/staticmaps/tilemanager.test.ts
@@ -1,6 +1,7 @@
 import { TileManager, TileServerConfig } from "../../src/staticmaps/tilemanager"
 import * as cache from "../../src/utils/cache"
 import * as utils from "../../src/staticmaps/utils"
+import { safeFetch } from "../../src/utils/safeFetch"
 import logger from "../../src/utils/logger"
 
 describe("TileServerConfig", () => {
@@ -35,8 +36,10 @@ describe("TileServerConfig", () => {
   })
 })
 
-// Mock fetch globally for all tests
-global.fetch = jest.fn()
+// Mock the outbound fetch used by TileManager
+jest.mock("../../src/utils/safeFetch", () => ({
+  safeFetch: jest.fn(),
+}))
 
 // Mock logger to avoid actual logs during tests
 jest.mock("../../src/utils/logger", () => ({
@@ -92,7 +95,7 @@ describe("TileManager", () => {
     it("fetches tile successfully and caches it", async () => {
       const arrayBuffer = new Uint8Array([1, 2, 3]).buffer
       ;(cache.getCachedTile as jest.Mock).mockReturnValue(null)
-      ;(global.fetch as jest.Mock).mockResolvedValue({
+      ;(safeFetch as jest.Mock).mockResolvedValue({
         ok: true,
         headers: { get: () => "image/png" },
         arrayBuffer: () => Promise.resolve(arrayBuffer),
@@ -101,10 +104,7 @@ describe("TileManager", () => {
       const tm = new TileManager({ tileLayers })
       const result = await tm.getTile(tileData)
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        tileData.url,
-        expect.any(Object)
-      )
+      expect(safeFetch).toHaveBeenCalledWith(tileData.url, expect.any(Object))
       expect(result.success).toBe(true)
       expect(result.tile?.url).toBe(tileData.url)
       expect(result.tile?.body).toBeInstanceOf(Buffer)
@@ -114,7 +114,7 @@ describe("TileManager", () => {
 
     it("returns error if fetch response is not ok", async () => {
       ;(cache.getCachedTile as jest.Mock).mockReturnValue(null)
-      ;(global.fetch as jest.Mock).mockResolvedValue({
+      ;(safeFetch as jest.Mock).mockResolvedValue({
         ok: false,
         statusText: "Not Found",
         headers: { get: () => "image/png" },
@@ -129,7 +129,7 @@ describe("TileManager", () => {
 
     it("returns error if content-type is not image/*", async () => {
       ;(cache.getCachedTile as jest.Mock).mockReturnValue(null)
-      ;(global.fetch as jest.Mock).mockResolvedValue({
+      ;(safeFetch as jest.Mock).mockResolvedValue({
         ok: true,
         headers: { get: () => "application/json" },
         arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
@@ -144,7 +144,7 @@ describe("TileManager", () => {
 
     it("returns error if fetch throws", async () => {
       ;(cache.getCachedTile as jest.Mock).mockReturnValue(null)
-      ;(global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"))
+      ;(safeFetch as jest.Mock).mockRejectedValue(new Error("Network error"))
 
       const tm = new TileManager({ tileLayers })
       const result = await tm.getTile(tileData)

--- a/__tests__/utils/safeFetch.test.ts
+++ b/__tests__/utils/safeFetch.test.ts
@@ -1,0 +1,145 @@
+﻿import dns from "node:dns"
+import { pinnedLookup, safeFetch } from "../../src/utils/safeFetch"
+
+jest.mock("node:dns", () => ({
+  __esModule: true,
+  default: { lookup: jest.fn() },
+}))
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}))
+
+const lookupMock = dns.lookup as unknown as jest.Mock
+
+/** Makes dns.lookup resolve `hostname` to the given addresses. */
+function mockResolve(addresses: Array<{ address: string; family: number }>) {
+  lookupMock.mockImplementation((_host: string, _opts: any, cb: any) =>
+    cb(null, addresses)
+  )
+}
+
+/** Runs pinnedLookup and captures its callback arguments. */
+function runLookup(
+  hostname: string
+): Promise<{ err: Error | null; address: string }> {
+  return new Promise((resolve) => {
+    pinnedLookup(hostname, {}, (err: any, address: any) =>
+      resolve({ err, address: address as string })
+    )
+  })
+}
+
+afterEach(() => {
+  delete process.env.ALLOW_PRIVATE_TILE_HOSTS
+  lookupMock.mockReset()
+})
+
+describe("pinnedLookup", () => {
+  it("blocks a public hostname that resolves to a private address", async () => {
+    // The hostname is neither a literal IP nor on any deny-list, so nothing
+    // about the string itself reveals where it points. Only resolving does.
+    mockResolve([{ address: "127.0.0.1", family: 4 }])
+
+    const { err } = await runLookup("tiles.example.com")
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err?.message).toMatch(/Blocked private address/)
+  })
+
+  it("blocks when only one of several records is private", async () => {
+    // Accepting the host because one record is public would still leave the
+    // connection free to use the private one.
+    mockResolve([
+      { address: "93.184.216.34", family: 4 },
+      { address: "169.254.169.254", family: 4 },
+    ])
+
+    const { err } = await runLookup("multi.example.com")
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err?.message).toMatch(/Blocked private address/)
+  })
+
+  it("pins the connection to the address it validated", async () => {
+    // Returning a concrete IP rather than the hostname avoids a second
+    // resolution, so the connection uses the address that was checked.
+    mockResolve([{ address: "93.184.216.34", family: 4 }])
+
+    const { err, address } = await runLookup("example.com")
+
+    expect(err).toBeNull()
+    expect(address).toBe("93.184.216.34")
+  })
+
+  it("allows private addresses for allowlisted hosts", async () => {
+    // Self-hosted tile servers on a Docker network must keep working.
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = "tileserver"
+    mockResolve([{ address: "172.20.0.5", family: 4 }])
+
+    const { err, address } = await runLookup("tileserver")
+
+    expect(err).toBeNull()
+    expect(address).toBe("172.20.0.5")
+  })
+
+  it("fails closed when resolution errors", async () => {
+    // A resolution failure says nothing about where the host points, so it
+    // must not be read as "not private".
+    lookupMock.mockImplementation((_host: string, _opts: any, cb: any) =>
+      cb(new Error("ENOTFOUND"), [])
+    )
+
+    const { err } = await runLookup("broken.example.com")
+
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it("fails closed when resolution returns no records", async () => {
+    mockResolve([])
+
+    const { err } = await runLookup("empty.example.com")
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err?.message).toMatch(/No addresses resolved/)
+  })
+})
+
+describe("safeFetch", () => {
+  it("rejects non-HTTP(S) schemes before any connection is attempted", async () => {
+    await expect(safeFetch("file:///etc/passwd")).rejects.toThrow(
+      /Blocked non-HTTP\(S\) scheme/
+    )
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a malformed URL", async () => {
+    await expect(safeFetch("not-a-url")).rejects.toThrow(/Invalid URL/)
+  })
+
+  // Node skips DNS when the host is already an IP literal, so pinnedLookup
+  // never fires for these. Without an explicit check they connect unguarded.
+  it.each([
+    ["http://127.0.0.1:8080/x.png", "IPv4 loopback"],
+    ["http://[::1]:8080/x.png", "IPv6 loopback"],
+    ["http://169.254.169.254/latest/meta-data/", "cloud metadata"],
+    ["http://192.168.1.1/x.png", "RFC1918"],
+  ])("blocks literal private address %s (%s)", async (url) => {
+    await expect(safeFetch(url)).rejects.toThrow(/Blocked private address/)
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it("allows a literal private address when the host is allowlisted", async () => {
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = "127.0.0.1"
+    // Port 1 refuses the connection, so this still rejects - but with a
+    // network error rather than the guard, proving the guard let it through.
+    const err = await safeFetch("http://127.0.0.1:1/x.png").catch((e) => e)
+    expect(String(err.message)).not.toMatch(/Blocked private address/)
+  })
+})

--- a/__tests__/utils/security.test.ts
+++ b/__tests__/utils/security.test.ts
@@ -1,11 +1,17 @@
-import {
+﻿import {
   isPrivateUrl,
   isSafeOutboundUrl,
+  isPrivateIp,
+  allowsPrivateAddress,
   escapeXml,
   redactUrl,
   replacePlaceholders,
   sanitizeTileHeaders,
 } from "../../src/utils/security"
+
+afterEach(() => {
+  delete process.env.ALLOW_PRIVATE_TILE_HOSTS
+})
 
 describe("isPrivateUrl", () => {
   test.each([
@@ -44,6 +50,125 @@ describe("isPrivateUrl", () => {
 
   test("blocks hex IP encoding", () => {
     expect(isPrivateUrl("http://0x7f000001/tiles")).toBe(true)
+  })
+
+  test.each([
+    ["https://ffmpeg.org/logo.png", "ff- prefix is not multicast"],
+    ["https://fcbarcelona.com/tile.png", "fc- prefix is not ULA"],
+    ["https://fdroid.link/tile.png", "fd- prefix is not ULA"],
+    ["https://fe80.example.com/tile.png", "fe80- prefix is not link-local"],
+  ])("allows real domain %s (%s)", (url) => {
+    // IPv6 range checks must only apply to IPv6 literals, otherwise these
+    // perfectly ordinary domains get rejected.
+    expect(isPrivateUrl(url)).toBe(false)
+  })
+
+  test.each([
+    ["http://[fd00::1]/tiles", "ULA literal"],
+    ["http://[fe80::1]/tiles", "link-local literal"],
+    ["http://[ff02::1]/tiles", "multicast literal"],
+    ["http://[::1]/tiles", "loopback literal"],
+    ["http://[0::1]/tiles", "non-canonical loopback"],
+    ["http://[::ffff:127.0.0.1]/tiles", "IPv4-mapped loopback"],
+  ])("still blocks IPv6 literal %s (%s)", (url) => {
+    expect(isPrivateUrl(url)).toBe(true)
+  })
+
+  test("allows a public IPv6 literal", () => {
+    expect(isPrivateUrl("http://[2606:4700:4700::1111]/tiles")).toBe(false)
+  })
+
+  test("blocks CGNAT range 100.64/10", () => {
+    // Looks routable but is internal, same exposure as RFC1918.
+    expect(isPrivateUrl("http://100.64.0.1/tiles")).toBe(true)
+    expect(isPrivateUrl("http://100.127.255.255/tiles")).toBe(true)
+    expect(isPrivateUrl("http://100.63.0.1/tiles")).toBe(false)
+    expect(isPrivateUrl("http://100.128.0.1/tiles")).toBe(false)
+  })
+
+  test("allows literal private IPs only when explicitly allowlisted", () => {
+    // Running your own tile server on the LAN is a normal setup, so there
+    // has to be a way to opt back in.
+    expect(isPrivateUrl("http://192.168.1.50:8080/tiles")).toBe(true)
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = "192.168.1.50"
+    expect(isPrivateUrl("http://192.168.1.50:8080/tiles")).toBe(false)
+  })
+
+  test("allowlist never permits non-HTTP(S) schemes", () => {
+    // The exemption covers addresses, not protocols - otherwise it would
+    // reopen file:// and gopher://.
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = "evil.test"
+    expect(isPrivateUrl("gopher://evil.test/x")).toBe(true)
+    expect(isPrivateUrl("file://evil.test/x")).toBe(true)
+  })
+})
+
+describe("allowsPrivateAddress", () => {
+  test("is case-insensitive and ignores surrounding whitespace", () => {
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = " TileServer , other.host "
+    expect(allowsPrivateAddress("tileserver")).toBe(true)
+    expect(allowsPrivateAddress("other.host")).toBe(true)
+    expect(allowsPrivateAddress("unlisted.host")).toBe(false)
+  })
+
+  test("denies everything when unset", () => {
+    expect(allowsPrivateAddress("tileserver")).toBe(false)
+  })
+
+  test("picks up env changes without a restart", () => {
+    // The parsed set is cached, so make sure the cache actually invalidates.
+    expect(allowsPrivateAddress("tileserver")).toBe(false)
+    process.env.ALLOW_PRIVATE_TILE_HOSTS = "tileserver"
+    expect(allowsPrivateAddress("tileserver")).toBe(true)
+  })
+})
+
+describe("isPrivateIp", () => {
+  // Runs on addresses coming back from DNS, so the input is always a
+  // canonical literal rather than something a caller typed.
+  test.each([
+    ["127.0.0.1", "IPv4 loopback"],
+    ["10.1.2.3", "RFC1918 10/8"],
+    ["172.20.0.5", "Docker default bridge range"],
+    ["192.168.0.1", "RFC1918 192.168/16"],
+    ["169.254.169.254", "cloud metadata endpoint"],
+    ["100.64.0.1", "CGNAT"],
+    ["::1", "IPv6 loopback"],
+    ["fd00::1", "IPv6 ULA"],
+    ["fe80::1", "IPv6 link-local"],
+    ["ff02::1", "IPv6 multicast"],
+    ["::ffff:127.0.0.1", "IPv4-mapped loopback"],
+    ["fe80::1%eth0", "zone-indexed link-local"],
+    // Not routable on the public internet, so a host resolving here is
+    // either misconfigured or pointing at something local.
+    ["192.0.0.1", "IETF protocol assignments 192.0.0.0/24"],
+    ["198.18.0.1", "benchmarking 198.18/15"],
+    ["198.19.255.255", "benchmarking 198.18/15 upper"],
+    ["224.0.0.1", "IPv4 multicast"],
+    ["239.255.255.250", "SSDP multicast"],
+    ["240.0.0.1", "reserved 240.0.0.0/4"],
+    ["255.255.255.255", "broadcast"],
+  ])("blocks %s (%s)", (ip) => {
+    expect(isPrivateIp(ip)).toBe(true)
+  })
+
+  test.each([
+    ["8.8.8.8", "public IPv4"],
+    ["151.101.1.140", "public IPv4"],
+    ["2606:4700:4700::1111", "public IPv6"],
+    ["::ffff:8.8.8.8", "IPv4-mapped public"],
+    // Boundaries of the reserved ranges above - these are ordinary routable
+    // addresses and must keep working, or public tile servers break.
+    ["192.0.1.1", "just past 192.0.0.0/24"],
+    ["198.17.255.255", "just below 198.18/15"],
+    ["198.20.0.1", "just past 198.18/15"],
+    ["223.255.255.255", "just below multicast"],
+  ])("allows %s (%s)", (ip) => {
+    expect(isPrivateIp(ip)).toBe(false)
+  })
+
+  test("fails closed on an unparseable IPv6 address", () => {
+    expect(isPrivateIp("::zzzz")).toBe(true)
   })
 })
 
@@ -121,19 +246,19 @@ describe("sanitizeTileHeaders", () => {
   test("allows whitelisted headers", () => {
     const result = sanitizeTileHeaders({
       "user-agent": "MyApp/1.0",
-      accept: "image/png",
+      "accept": "image/png",
     })
     expect(result).toEqual({
       "user-agent": "MyApp/1.0",
-      accept: "image/png",
+      "accept": "image/png",
     })
   })
 
   test("strips non-whitelisted headers", () => {
     const result = sanitizeTileHeaders({
       "user-agent": "MyApp/1.0",
-      authorization: "Bearer token",
-      cookie: "session=abc",
+      "authorization": "Bearer token",
+      "cookie": "session=abc",
     })
     expect(result).toEqual({ "user-agent": "MyApp/1.0" })
   })

--- a/docs/docs/administration-guide/configuration.md
+++ b/docs/docs/administration-guide/configuration.md
@@ -26,12 +26,59 @@ You can configure the **Docker Static Maps API** through environment variables.
 | `LOG_LEVEL` | string | INFO | Logging level (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 | `TILE_CACHE_TTL` | number | 3600 | Tile cache TTL in seconds |
 | `DISABLE_TILE_CACHE` | boolean | false | Set to `true` to disable tile caching |
+| `TILE_USER_AGENT` | string | `docker-staticmaps (+<repo URL>)` | `User-Agent` sent when fetching tiles. See [Identifying your deployment to tile servers](#identifying-your-deployment-to-tile-servers). |
 | `MAX_BODY_SIZE` | string | 100kb | Controls the maximum request body size |
 | `MAX_PARAMETER_LIMIT` | number | 1000 | Controls the maximum number of parameters that are allowed in the URL-encoded data |
 | `RATE_LIMIT_MS` | number | 60000 | Rate limit window in milliseconds |
 | `RATE_LIMIT_MAX` | number | 60 | Max requests per IP per window |
 | `HILLSHADE_TILE_URL` | string | AWS Open Data Terrarium endpoint | Tile URL template for the optional hillshade overlay. Must serve Terrarium-encoded raster-DEM tiles. |
 | `HILLSHADE_ATTRIBUTION` | string | `Hillshade: Mapzen / AWS Terrain Tiles` | Short-form attribution appended when `hillshade=true` is set. Override when pointing `HILLSHADE_TILE_URL` at a non-Mapzen DEM source. |
+| `ALLOW_PRIVATE_TILE_HOSTS` | string | (none) | Comma-separated hostnames permitted to resolve to private/internal addresses. See [Using a tile server on your own network](#using-a-tile-server-on-your-own-network). |
+
+---
+
+## Identifying your deployment to tile servers
+
+OpenStreetMap's [tile usage policy](https://operations.osmfoundation.org/policies/tiles/) requires clients to identify themselves. Requests without a meaningful `User-Agent` are served an "Access blocked" placeholder image **with HTTP 200 and `Content-Type: image/png`**, so the map renders successfully but every tile reads "App is not following the tile usage policy".
+
+A default `User-Agent` identifying docker-staticmaps is sent automatically. If you run a public or high-traffic instance, set `TILE_USER_AGENT` to something that identifies _your_ deployment and gives operators a way to contact you:
+
+```yaml
+environment:
+  - TILE_USER_AGENT=my-maps.example.com (admin@example.com)
+```
+
+Note that `TILE_USER_AGENT=` with an empty value counts as unset, and the default is used.
+
+---
+
+## Using a tile server on your own network
+
+User-supplied `tileUrl` and marker `img` values are fetched by the server, so requests that reach private or internal addresses are blocked. The check runs at connection time against the resolved IP, so it also covers hostnames that resolve to internal addresses and DNS-rebinding attempts.
+
+**Public tile servers need no configuration.** Every built-in `basemap` (`osm`, `otm`, `satellite`, `carto-light`, …) and any public custom `tileUrl` works out of the box, because those hosts resolve to public addresses.
+
+`ALLOW_PRIVATE_TILE_HOSTS` is **not** a list of permitted tile servers - it is a narrow exemption from the private-address check. Adding a public host such as `tile.openstreetmap.org` does nothing useful and only removes that host's protection, so leave it unset unless you are self-hosting tiles.
+
+You need it only when your tile server is on a LAN or Docker network:
+
+```yaml
+services:
+  staticmaps:
+    image: mxdcodes/docker-staticmaps:latest
+    environment:
+      - ALLOW_PRIVATE_TILE_HOSTS=tileserver,tiles.homelab.lan
+```
+
+```bash
+curl "http://localhost:3000/api/staticmaps?width=600&height=400&center=13.4,52.5&zoom=12&tileUrl=http://tileserver:8080/{z}/{x}/{y}.png"
+```
+
+Entries match the URL hostname exactly (case-insensitive); there is no wildcard or subdomain matching, and an entry may be a hostname or a literal IP. Only add hosts you control.
+
+Non-HTTP(S) schemes such as `file://` are always rejected, exemption or not.
+
+If you point `HILLSHADE_TILE_URL` at a DEM server on your own network, its hostname needs listing here too.
 
 ---
 
@@ -64,7 +111,7 @@ curl -H "x-api-key: your_api_key_here" \
 http://localhost:3000/api/staticmaps?width=600&height=600&center=40.7128,-74.006&zoom=12&API_KEY=your_api_key_here
 ```
 
-✅ Both methods are supported for **all endpoints**, including demo maps.
+Both methods are supported for **all endpoints**, including demo maps.
 
 ---
 

--- a/docs/docs/api-reference/basemap.md
+++ b/docs/docs/api-reference/basemap.md
@@ -23,20 +23,18 @@ Use the `basemap` parameter to select a predefined basemap or specify a `custom`
 | `otm` | [OpenTopoMap](https://www.opentopomap.org/) |
 | `streets` | Esri [Streets](https://www.arcgis.com/home/webmap/viewer.html?webmap=7990d7ea55204450b8110d57e20c99ab) |
 | `satellite` | Esri [Satellite](https://www.arcgis.com/home/webmap/viewer.html?webmap=d802f08316e84c6592ef681c50178f17&center=-71.055499,42.364247&level=15) |
-| `hybrid` | Esri Hybrid (satellite + labels) |
 | `topo` | Esri [Topographic](https://www.arcgis.com/home/webmap/viewer.html?webmap=a72b0766aea04b48bf7a0e8c27ccc007) |
-| `gray` | Esri Gray w/ labels |
 | `gray-background` | Esri [Gray background only](https://www.arcgis.com/home/webmap/viewer.html?webmap=8b3d38c0819547faa83f7b7aca80bd76) |
 | `hillshade` | Esri [Hillshade](https://www.arcgis.com/home/item.html?id=1b243539f4514b6ba35e7d995890db1d) |
 | `national-geographic` | [National Geographic](https://www.arcgis.com/home/webmap/viewer.html?webmap=d94dcdbe78e141c2b2d3a91d5ca8b9c9) |
-| `stamen-toner` | [Stamen Toner (B/W)](http://maps.stamen.com/toner/) |
-| `stamen-watercolor` | [Stamen Watercolor](http://maps.stamen.com/watercolor/) |
 | `carto-light` | [Carto Light](https://carto.com/location-data-services/basemaps/) |
 | `carto-dark` | [Carto Dark](https://carto.com/location-data-services/basemaps/) |
-
+| `carto-voyager` | [Carto Voyager](https://carto.com/location-data-services/basemaps/) |
 
 ```
 &basemap=osm
 ```
 
 Make sure to respect the usage policy of each provider!
+
+A custom `tileUrl` is rejected if its host resolves to a private or internal address. Tile servers on a LAN or Docker network need their hostname listed in `ALLOW_PRIVATE_TILE_HOSTS` (see **Configuration**).

--- a/docs/docs/api-reference/circles.md
+++ b/docs/docs/api-reference/circles.md
@@ -24,12 +24,12 @@ circle=circleStyle|circleCoord
 - **circleCoord**: Coordinates for the circle's center in lat, lon format, separated by |. You need at least one coordinate.
 - **circleStyle**: Customize the circle with:
 
-  | Parameter | Default    | Description                              |
-  | --------- | ---------- | ---------------------------------------- |
-  | `radius`  | (required) | Specifies the radius of the element.     |
-  | `color`   | `#0000bb`  | Defines the stroke color of the element. |
-  | `width`   | `3`        | Sets the stroke width of the element.    |
-  | `fill`    | `{color}`  | Specifies the fill color of the element. |
+  | Parameter | Default   | Description                              |
+  | --------- | --------- | ---------------------------------------- |
+  | `radius`  | `10`      | Radius of the circle in meters.          |
+  | `color`   | `#4874db` | Defines the stroke color of the element. |
+  | `width`   | `3`       | Sets the stroke width of the element.    |
+  | `fill`    | `{color}` | Specifies the fill color of the element. |
 
 **Example**: Circle with a radius of `20` meters.
 

--- a/docs/docs/api-reference/markers.md
+++ b/docs/docs/api-reference/markers.md
@@ -26,14 +26,14 @@ markers=markerStyle|markerCoord1|markerCoord2|...
 
   | Parameter | Default | Description |
   | --- | --- | --- |
-  | `img` | (optional) | URL or file path for a custom marker image. |
+  | `img` | (optional) | URL of a custom marker image. Rejected if the host resolves to a private or internal address (see **Configuration**). If omitted, a colored pin is drawn instead. |
   | `color` | `#d9534f` | Color of the Marker. |
   | `width` | `28` | Width of marker image in px. |
   | `height` | `28` | Height of marker image in px. |
   | `drawWidth` | `width` | Resize marker image to width in px. |
   | `drawHeight` | `height` | Resize marker image to height in px. |
-  | `offsetX` | `13.5` | Horizontal offset for the marker position. |
-  | `offsetY` | `27.5` | Vertical offset for the marker position. |
+  | `offsetX` | `14` | Horizontal offset for the marker position. |
+  | `offsetY` | `28` | Vertical offset for the marker position. |
   | `resizeMode` | `cover` | Applied resize method if needed. See: [https://sharp.pixelplumbing.com/api-resize](https://sharp.pixelplumbing.com/api-resize) |
 
 <details>

--- a/docs/docs/api-reference/parameters.md
+++ b/docs/docs/api-reference/parameters.md
@@ -19,32 +19,46 @@ Request static maps from the `/api/staticmaps` endpoint using the following para
 
 ## Required Parameters
 
+You must supply either `center` or at least one feature with coordinates (`markers`, `polyline`, `polygon`, `circle`, `text`); a request with neither is rejected with HTTP 422.
+
 | Parameter | Default | Description |
 | --- | --- | --- |
-| `center` | (required) | Center of map (`lon,lat`, e.g. `-119.49280,37.81084`) |
-| `zoom` | (required) | Zoom level (`1` to `18`). |
+| `center` | (required unless a feature supplies coordinates) | Center of map (`lon,lat`, e.g. `-119.49280,37.81084`) |
 
 ## Optional Parameters
 
 | Parameter | Default | Description |
 | --- | --- | --- |
+| `zoom` | (fitted to content) | Zoom level (`1` to `20`). Omit to fit the map to its features using `zoomRange`. |
 | `width` | `800` | Width of the output image in pixels. Min: 1, Max: 8192. |
-| `height` | `800` | Heihgt of the output image in pixels. Min: 1, Max: 8192. |
+| `height` | `800` | Height of the output image in pixels. Min: 1, Max: 8192. |
 | `paddingX` | `0` | Horizontal padding in pixels |
 | `paddingY` | `0` | Vertical padding in pixels |
-| `format` | `png` | Output format: `png`, `jpg`, `webp` or `pdf` |
+| `format` | `png` | Output format: `png`, `jpg`, `jpeg`, `webp` or `pdf` |
 | `quality` | `100` | Image quality (0–100) for `jpg`/`webp` |
 | `basemap` | `osm` | Tile layer (see **Basemap** for supported types) |
 | `attribution` |  | Attribution text (see **Attribution**) |
-| `tileUrl` |  | Tile URL with `{x}`, `{y}`, `{z}` or `{quadkey}` placeholders |
-| `tileSubdomains` | `[]` | Tile subdomains like `['a', 'b', 'c']` |
-| `tileLayers` | `[]` | Multiple tile layers with `tileUrl` and `tileSubdomains` |
+| `tileUrl` |  | Tile URL with `{x}`, `{y}`, `{z}` or `{quadkey}` placeholders. Rejected if the host resolves to a private or internal address (see **Configuration**). |
+| `tileSubdomains` | `[]` | Tile subdomains like `['a', 'b', 'c']`. Max 10; entries must match `[a-zA-Z0-9-]+`. |
+| `tileLayers` | `[]` | Multiple tile layers with `tileUrl` and `tileSubdomains`. Max 10 layers. |
 | `tileSize` | `256` | Size of tiles in pixels |
-| `tileRequestTimeout` |  | Tile request timeout (ms) |
-| `tileRequestHeader` | `{}` | Extra headers for tile requests |
-| `tileRequestLimit` | `2` | Max parallel tile requests |
+| `tileRequestTimeout` |  | Tile request timeout (ms). Capped at 30000. |
+| `tileRequestHeader` | `{}` | Extra headers for tile requests. Only `User-Agent`, `Accept`, `Accept-Language`, `Referer` and `Cache-Control` are forwarded; all others are dropped. |
+| `tileRequestLimit` | `2` | Max parallel tile requests. Capped at 8. |
 | `zoomRange` | `{ min: 1, max: 17 }` | Min and max zoom to try |
 | `reverseY` | `false` | Use TMS-style Y axis if `true` |
 | `hillshade` | `false` | Composite a shaded-relief overlay on top of the basemap (see **Hillshade**) |
+
+---
+
+## Limits
+
+Requests exceeding these are rejected rather than silently truncated:
+
+| Limit | Value |
+| --- | --- |
+| Image dimensions | 8192 x 8192, and at most 25,000,000 pixels total |
+| Features per request | 1000 across `markers`, `polyline`, `polygon`, `circle` and `text` combined |
+| Zoom | 20 |
 
 ---

--- a/docs/docs/api-reference/polygons.md
+++ b/docs/docs/api-reference/polygons.md
@@ -27,7 +27,7 @@ polygon=polygonStyle|polygonCoord1|polygonCoord2|...
   | Parameter | Default | Description |
   | --- | --- | --- |
   | `color` | `#4874db` | Defines the stroke color of the polygon. |
-  | `weight` | `5` | Sets the stroke width of the polygon. |
+  | `weight` | `3` | Sets the stroke width of the polygon. |
   | `fill` |  | Specifies the fill color of the polygon. |
   | `strokeDasharray` | (none) | Pattern of dashes and gaps, e.g., `5,5` see [stroke-dasharray](https://developer.mozilla.org/de/docs/Web/CSS/stroke-dasharray). |
 

--- a/docs/docs/api-reference/polylines.md
+++ b/docs/docs/api-reference/polylines.md
@@ -30,7 +30,7 @@ polyline=polylineStyle|polylineCoord1|polylineCoord2|...
   | Parameter | Default | Description |
   | --- | --- | --- |
   | `weight` | `6` | Sets the stroke width of the polyline. |
-  | `color` | `#0000ff` | Defines the stroke color of the polyline. |
+  | `color` | `blue` | Defines the stroke color of the polyline. |
   | `fill` |  | Specifies the fill color of the polyline. |
   | `strokeDasharray` | (none) | Pattern of dashes and gaps, e.g., `5,5` see [stroke-dasharray](https://developer.mozilla.org/de/docs/Web/CSS/stroke-dasharray). |
   | `withGeodesicLine` | `true` | When `true`, generates geodesic lines between each pair of coordinates. Set to `false` to draw straight lines. |

--- a/docs/docs/api-reference/text.md
+++ b/docs/docs/api-reference/text.md
@@ -29,12 +29,12 @@ text=textStyle|textCoord
   | `text`    | (required)  | The text to render.                           |
   | `color`   | `#000000BB` | Stroke color of the text                      |
   | `width`   | `1`         | Stroke width of the text                      |
-  | `fill`    | `#000000`   | Fill color of the text                        |
+  | `fill`    | `{color}`   | Fill color of the text                        |
   | `size`    | `12`        | Font-size of the text                         |
   | `font`    | `Arial`     | Font-family of the text                       |
   | `anchor`  | `start`     | Determines the text anchor alignment.         |
-  | `offsetX` | `0`         | Horizontal offset relative to the coordinate. |
-  | `offsetY` | `0`         | Vertical offset relative to the coordinate.   |
+  | `offsetX` | `-12`       | Horizontal offset relative to the coordinate. |
+  | `offsetY` | `22`        | Vertical offset relative to the coordinate.   |
 
 **Example**: Text "Hello World" with custom styling.
 

--- a/src/staticmaps/renderer.ts
+++ b/src/staticmaps/renderer.ts
@@ -13,6 +13,7 @@ import { Text, Polyline, Circle, IconMarker } from "./features"
 import sharp from "sharp"
 import type { FitEnum, ResizeOptions } from "sharp"
 import { isSafeOutboundUrl, escapeXml } from "../utils/security"
+import { safeFetch, type SafeResponse } from "../utils/safeFetch"
 import { terrariumToHillshade } from "./hillshade"
 import logger from "../utils/logger"
 
@@ -212,12 +213,10 @@ export function lineToSVG({
   if (!line.coords || line.coords.length < 2) return ""
 
   // Project coordinates to pixels
-  const pixels = line.coords.map(
-    ([lon, lat]: Coordinate): Coordinate => [
-      xToPx(lonToX(lon, zoom)),
-      yToPx(latToY(lat, zoom)),
-    ]
-  )
+  const pixels = line.coords.map(([lon, lat]: Coordinate): Coordinate => [
+    xToPx(lonToX(lon, zoom)),
+    yToPx(latToY(lat, zoom)),
+  ])
 
   // Smooth or use original points depending on type
   const points =
@@ -469,9 +468,12 @@ export async function loadMarkers(
         }
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 10_000)
-        let response: globalThis.Response
+        let response: SafeResponse
         try {
-          response = await fetch(icon.file, { method: "GET", redirect: "manual" as RequestRedirect, signal: controller.signal })
+          response = await safeFetch(icon.file, {
+            signal: controller.signal,
+            maxBytes: 5 * 1024 * 1024,
+          })
         } finally {
           clearTimeout(timeoutId)
         }
@@ -483,10 +485,6 @@ export async function loadMarkers(
         const contentType = response.headers.get("content-type")
         if (!contentType || !contentType.startsWith("image/")) {
           throw new Error(`Marker URL did not return an image: ${icon.file}`)
-        }
-        const contentLength = Number(response.headers.get("content-length") || 0)
-        if (contentLength > 5 * 1024 * 1024) {
-          throw new Error(`Marker image too large: ${contentLength} bytes`)
         }
         const arrayBuffer = await response.arrayBuffer()
         icon.data = await sharp(Buffer.from(arrayBuffer))

--- a/src/staticmaps/tilemanager.ts
+++ b/src/staticmaps/tilemanager.ts
@@ -1,6 +1,7 @@
 // TileManager.ts
 import { getCachedTile, setCachedTile } from "../utils/cache"
 import { workOnQueue } from "./utils"
+import { safeFetch } from "../utils/safeFetch"
 import logger from "../utils/logger"
 import { TileServerOptions } from "../types/types"
 
@@ -83,15 +84,16 @@ export class TileManager {
     const timeoutId = setTimeout(() => controller.abort(), timeout)
 
     try {
-      const res = await fetch(data.url, {
-        method: "GET",
+      const res = await safeFetch(data.url, {
         headers,
-        redirect: "manual" as RequestRedirect,
         signal: controller.signal,
+        maxBytes: 10 * 1024 * 1024,
       })
 
       if (res.status >= 300 && res.status < 400) {
-        throw new Error(`Tile server returned redirect (${res.status}), blocked for security`)
+        throw new Error(
+          `Tile server returned redirect (${res.status}), blocked for security`
+        )
       }
       if (!res.ok) {
         throw new Error(`Failed to fetch tile: ${res.statusText}`)
@@ -102,11 +104,6 @@ export class TileManager {
       const contentType = res.headers.get("content-type")
       if (!contentType || !contentType.startsWith("image/")) {
         throw new Error("Tiles server response with wrong data")
-      }
-
-      const contentLength = Number(res.headers.get("content-length") || 0)
-      if (contentLength > 10 * 1024 * 1024) {
-        throw new Error(`Tile response too large: ${contentLength} bytes`)
       }
 
       const arrayBuffer = await res.arrayBuffer()

--- a/src/utils/safeFetch.ts
+++ b/src/utils/safeFetch.ts
@@ -1,0 +1,170 @@
+/**
+ * @module utils/safeFetch
+ * Outbound HTTP(S) fetch for untrusted URLs.
+ */
+
+import http from "node:http"
+import https from "node:https"
+import dns from "node:dns"
+import net, { type LookupFunction } from "node:net"
+import { isPrivateIp, allowsPrivateAddress } from "./security"
+import logger from "./logger"
+
+/**
+ * Sent when the caller supplies no User-Agent. Tile servers such as
+ * OpenStreetMap serve a "blocked" placeholder tile to unidentified clients,
+ * so an anonymous request looks like a success but renders the wrong image.
+ * Override per-deployment with TILE_USER_AGENT.
+ */
+const DEFAULT_USER_AGENT =
+  "docker-staticmaps (+https://github.com/dietrichmax/docker-staticmaps)"
+
+/** Minimal fetch-like response surface used by the tile and marker fetchers. */
+export interface SafeResponse {
+  status: number
+  statusText: string
+  ok: boolean
+  headers: { get(name: string): string | null }
+  arrayBuffer(): Promise<ArrayBuffer>
+}
+
+/**
+ * DNS lookup that refuses to hand back a private address.
+ *
+ * Resolves all records, blocks if any is private, then returns a single
+ * validated address so the socket connects to exactly what was checked.
+ * Hosts in ALLOW_PRIVATE_TILE_HOSTS skip the private-address check.
+ */
+export const pinnedLookup: LookupFunction = (hostname, options, callback) => {
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) return callback(err, "", 0)
+
+    const list = addresses as dns.LookupAddress[]
+    if (!list.length) {
+      return callback(new Error(`No addresses resolved for ${hostname}`), "", 0)
+    }
+
+    if (!allowsPrivateAddress(hostname)) {
+      const blocked = list.find((a) => isPrivateIp(a.address))
+      if (blocked) {
+        logger.warn(
+          `Blocked outbound request: ${hostname} resolves to private address ${blocked.address}`
+        )
+        return callback(
+          new Error(`Blocked private address for host ${hostname}`),
+          "",
+          0
+        )
+      }
+    }
+
+    // autoSelectFamily (on by default since Node 20) passes all:true and
+    // expects the array back. Every entry is already validated.
+    if (options.all) return callback(null, list)
+
+    callback(null, list[0].address, list[0].family)
+  })
+}
+
+/**
+ * GETs an untrusted URL.
+ *
+ * Redirects are not followed; 3xx comes back as-is for the caller to reject.
+ * The body is capped while streaming, since Content-Length can be understated
+ * or omitted entirely.
+ */
+export function safeFetch(
+  urlString: string,
+  opts: {
+    headers?: Record<string, string>
+    signal?: AbortSignal
+    maxBytes?: number
+  } = {}
+): Promise<SafeResponse> {
+  return new Promise((resolve, reject) => {
+    let url: URL
+    try {
+      url = new URL(urlString)
+    } catch {
+      return reject(new Error(`Invalid URL: ${urlString}`))
+    }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return reject(new Error(`Blocked non-HTTP(S) scheme: ${url.protocol}`))
+    }
+
+    // Node skips DNS when the host is already an IP, so pinnedLookup never
+    // runs for literals - they have to be checked here instead.
+    const host = url.hostname.replace(/^\[|\]$/g, "")
+    if (net.isIP(host) && !allowsPrivateAddress(host) && isPrivateIp(host)) {
+      logger.warn(`Blocked outbound request to private address ${host}`)
+      return reject(new Error(`Blocked private address ${host}`))
+    }
+
+    const transport = url.protocol === "https:" ? https : http
+    const maxBytes = opts.maxBytes ?? 10 * 1024 * 1024
+
+    const headers = { ...opts.headers }
+    if (!Object.keys(headers).some((h) => h.toLowerCase() === "user-agent")) {
+      headers["User-Agent"] = DEFAULT_USER_AGENT
+    }
+
+    const req = transport.request(
+      url,
+      { method: "GET", headers, lookup: pinnedLookup },
+      (res) => {
+        const chunks: Buffer[] = []
+        let total = 0
+
+        res.on("data", (chunk: Buffer) => {
+          total += chunk.length
+          if (total > maxBytes) {
+            req.destroy()
+            reject(new Error(`Response too large: exceeded ${maxBytes} bytes`))
+            return
+          }
+          chunks.push(chunk)
+        })
+
+        res.on("end", () => {
+          const body = Buffer.concat(chunks)
+          const status = res.statusCode ?? 0
+          resolve({
+            status,
+            statusText: res.statusMessage ?? "",
+            ok: status >= 200 && status < 300,
+            headers: {
+              get(name: string): string | null {
+                const value = res.headers[name.toLowerCase()]
+                return Array.isArray(value) ? value.join(", ") : (value ?? null)
+              },
+            },
+            arrayBuffer: async () =>
+              body.buffer.slice(
+                body.byteOffset,
+                body.byteOffset + body.byteLength
+              ) as ArrayBuffer,
+          })
+        })
+
+        res.on("error", reject)
+      }
+    )
+
+    req.on("error", reject)
+
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        req.destroy()
+        return reject(new Error("Request aborted"))
+      }
+      opts.signal.addEventListener(
+        "abort",
+        () => req.destroy(new Error("Request aborted")),
+        { once: true }
+      )
+    }
+
+    req.end()
+  })
+}

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,9 +1,43 @@
+import net from "node:net"
 import logger from "./logger"
+
+/**
+ * Hosts exempt from the private-address checks, from the
+ * `ALLOW_PRIVATE_TILE_HOSTS` env var (comma-separated hostnames).
+ *
+ * Exists so people can run their own tile server on a LAN or Docker network.
+ * It is not a list of permitted tile servers - public hosts already work
+ * without being listed, and adding one here just removes its protection.
+ */
+let allowedHostsRaw: string | undefined
+let allowedHosts = new Set<string>()
+
+/**
+ * Whether this host may resolve to a private/internal address.
+ * Re-parses the env var only when it changes.
+ */
+export function allowsPrivateAddress(hostname: string): boolean {
+  const raw = process.env.ALLOW_PRIVATE_TILE_HOSTS ?? ""
+  if (raw !== allowedHostsRaw) {
+    allowedHostsRaw = raw
+    allowedHosts = new Set(
+      raw
+        .split(",")
+        .map((h) => h.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  }
+  return allowedHosts.has(hostname.toLowerCase().replace(/^\[|\]$/g, ""))
+}
 
 /**
  * Checks if a URL points to a private/internal network address.
  * Blocks: localhost, 127.x, ::1, 10.x, 172.16-31.x, 192.168.x,
- * 169.254.x, 0.x, .local, .internal, and non-HTTP(S) schemes.
+ * 169.254.x, 100.64-127.x, 0.x, 192.0.0.x, 198.18-19.x, multicast,
+ * reserved 240.x+, .local, .internal, and non-HTTP(S) schemes.
+ *
+ * Only looks at the URL string. Hostnames that resolve to a private address
+ * need DNS to catch, which happens at connect time in `safeFetch`.
  */
 export function isPrivateUrl(urlString: string): boolean {
   try {
@@ -12,6 +46,8 @@ export function isPrivateUrl(urlString: string): boolean {
     if (url.protocol !== "http:" && url.protocol !== "https:") return true
 
     const hostname = url.hostname.replace(/^\[|\]$/g, "")
+
+    if (allowsPrivateAddress(hostname)) return false
 
     if (
       hostname === "localhost" ||
@@ -24,15 +60,9 @@ export function isPrivateUrl(urlString: string): boolean {
     )
       return true
 
-    // IPv6 private ranges
-    const lowerHost = hostname.toLowerCase()
-    if (lowerHost.startsWith("fc") || lowerHost.startsWith("fd")) return true // ULA fc00::/7
-    if (lowerHost.startsWith("fe80")) return true // Link-local
-    if (lowerHost.startsWith("ff")) return true // Multicast
-    if (/^0{0,4}:{0,2}0{0,4}:{0,2}(0{0,4}:){0,3}[01]$/.test(lowerHost)) return true // ::1, ::, 0::1
-    // IPv4-mapped IPv6: ::ffff:W.X.Y.Z
-    const v4mapped = lowerHost.match(/^:{0,2}ffff:(\d+\.\d+\.\d+\.\d+)$/)
-    if (v4mapped) return isPrivateIpv4(v4mapped[1])
+    // Only for real IPv6 literals - matching prefixes against any hostname
+    // would reject domains like ffmpeg.org or fcbarcelona.com
+    if (net.isIPv6(hostname)) return isPrivateIpv6(hostname)
 
     // Quad-dotted IPv4
     const parts = hostname.split(".").map(Number)
@@ -56,9 +86,48 @@ function isPrivateIpv4(ip: string): boolean {
   if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true
   if (parts[0] === 192 && parts[1] === 168) return true
   if (parts[0] === 169 && parts[1] === 254) return true
+  if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true // CGNAT 100.64/10
   if (parts[0] === 0) return true
   if (parts[0] === 127) return true
+  if (parts[0] === 192 && parts[1] === 0 && parts[2] === 0) return true // IETF protocol assignments 192.0.0.0/24
+  if (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19)) return true // Benchmarking 198.18.0.0/15
+  if (parts[0] >= 224 && parts[0] <= 239) return true // Multicast 224.0.0.0/4
+  if (parts[0] >= 240) return true // Reserved 240.0.0.0/4, includes broadcast
   return false
+}
+
+/** Checks an IPv6 literal, either from a URL hostname or from dns.lookup. */
+function isPrivateIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase().split("%")[0] // strip zone index
+  // Must come before the ::/16 check below. dns.lookup gives the dotted form
+  // (::ffff:127.0.0.1), the URL parser normalises to hex (::ffff:7f00:1).
+  if (addr.startsWith("::ffff:")) {
+    const rest = addr.slice(7)
+    if (rest.includes(".")) return isPrivateIpv4(rest)
+
+    const [hi, lo] = rest.split(":").map((g) => parseInt(g, 16))
+    if (rest.split(":").length !== 2 || isNaN(hi) || isNaN(lo)) return true
+    return isPrivateIpv4(
+      `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
+    )
+  }
+
+  const first = parseInt(addr.split(":")[0], 16)
+  if (isNaN(first)) return true // "::1", "::", "::zzzz" - reserved or garbage
+  if (first === 0) return true // ::/16 reserved, covers 0::1
+  if ((first & 0xfe00) === 0xfc00) return true // ULA fc00::/7
+  if ((first & 0xffc0) === 0xfe80) return true // Link-local fe80::/10
+  if ((first & 0xff00) === 0xff00) return true // Multicast ff00::/8
+  return false
+}
+
+/**
+ * Classifies a resolved IP literal (v4 or v6) as private/internal.
+ * Used by the connect-time check in `safeFetch`, where the input is always
+ * a canonical address from dns.lookup rather than a user-supplied string.
+ */
+export function isPrivateIp(ip: string): boolean {
+  return ip.includes(":") ? isPrivateIpv6(ip) : isPrivateIpv4(ip)
 }
 
 /** Logs and rejects private/internal URLs before outbound fetches. */
@@ -114,7 +183,11 @@ export function sanitizeTileHeaders(
 
   const sanitized: Record<string, string> = {}
   for (const [key, value] of Object.entries(headers)) {
-    if (ALLOWED_TILE_HEADERS.has(key.toLowerCase()) && typeof value === "string" && !/[\r\n]/.test(value)) {
+    if (
+      ALLOWED_TILE_HEADERS.has(key.toLowerCase()) &&
+      typeof value === "string" &&
+      !/[\r\n]/.test(value)
+    ) {
       sanitized[key] = value
     }
   }


### PR DESCRIPTION
Fixes the SSRF bypass reported in GHSA-hm5x-363q-6q2p.

`isPrivateUrl()` only inspected the URL string, so any hostname resolving to a
private address bypassed it. Outbound fetches now resolve first, reject if any
record is private, and pin the connection to the validated address — which also
closes the DNS-rebinding window the report expected to survive a patch.

## Verification
- Reproduced the advisory's PoC (`127.0.0.1.nip.io`) against the patched build:
  blocked, zero hits on the internal service.
- All 11 built-in basemaps fetch real tiles; every resolved IPv4/IPv6 address passes.
- 405 tests, typecheck, and both webpack bundles clean.

## Breaking
Tile servers on a private network now need `ALLOW_PRIVATE_TILE_HOSTS`.
Public providers are unaffected and need no configuration.